### PR TITLE
Add developer info to readme, minor display tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,10 @@ Maybe, please create an issue (feature request) and I will consider it. As a wor
 ![preview image](https://imgur.com/Ngos9JZ.png)
 
 ![preview image](https://imgur.com/m46BzZj.png)
+
+## Development
+To open and build the solution, you need:
+
+* Visual Studio 2019 (v16.8.0 or newer)
+* [.NET 5.0 SDK](https://dotnet.microsoft.com/download/visual-studio-sdks)
+* The extension [Microsoft Visual Studio Installer Projects](https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects) to open the RaceControl.Installer project

--- a/RaceControl.sln
+++ b/RaceControl.sln
@@ -22,6 +22,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{114B4790-C604-4508-9E5A-1B07B513FF4E}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
+		LICENSE.md = LICENSE.md
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "RaceControl.Package", "RaceControl\RaceControl.Package\RaceControl.Package.wapproj", "{EA81E946-E298-4589-BB5E-86C6D9213FB7}"

--- a/RaceControl/Services/RaceControl.Services.Interfaces/F1TV/Entities/Event.cs
+++ b/RaceControl/Services/RaceControl.Services.Interfaces/F1TV/Entities/Event.cs
@@ -11,7 +11,15 @@ namespace RaceControl.Services.Interfaces.F1TV.Entities
 
         public override string ToString()
         {
-            return Name;
+            var startDate = StartDate?.ToString("dd\\/MM");
+            var endDate = EndDate?.ToString("dd\\/MM");
+
+            var hasDate = StartDate.HasValue || EndDate.HasValue;
+            var hasBothDatesAndDifferent = hasDate && StartDate != EndDate;
+
+            var dateString = !hasDate ? null : $" ({startDate}{(hasBothDatesAndDifferent ? "-" : "")}{endDate})";
+
+            return Name + dateString;
         }
     }
 }

--- a/RaceControl/Services/RaceControl.Services/F1TV/ApiService.cs
+++ b/RaceControl/Services/RaceControl.Services/F1TV/ApiService.cs
@@ -22,11 +22,13 @@ namespace RaceControl.Services.F1TV
 
         private readonly ILogger _logger;
         private readonly Func<IRestClient> _restClientFactory;
+        private readonly IEqualityComparer<Session> _sessionComparer;
 
         public ApiService(ILogger logger, Func<IRestClient> restClientFactory)
         {
             _logger = logger;
             _restClientFactory = restClientFactory;
+            _sessionComparer = new SessionComparer(); 
         }
 
         public List<Series> GetSeries()
@@ -86,6 +88,7 @@ namespace RaceControl.Services.F1TV
                 .SelectMany(c1 => c1.RetrieveItems.ResultObj.Containers
                     .Where(c2 => c2.Metadata.ContentType == "VIDEO" && c2.Metadata.ContentSubtype == "LIVE")
                     .Select(CreateSession))
+                    .Distinct(_sessionComparer)
                 .ToList();
         }
 
@@ -121,6 +124,7 @@ namespace RaceControl.Services.F1TV
                 .Where(c => c.Metadata.ContentType == "VIDEO")
                 .Where(c => c.Metadata.ContentSubtype == "REPLAY" || c.Metadata.ContentSubtype == "LIVE")
                 .Select(CreateSession)
+                .Distinct(_sessionComparer)
                 .ToList();
         }
 

--- a/RaceControl/Services/RaceControl.Services/F1TV/Comparers.cs
+++ b/RaceControl/Services/RaceControl.Services/F1TV/Comparers.cs
@@ -1,0 +1,19 @@
+﻿using RaceControl.Services.Interfaces.F1TV.Entities;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace RaceControl.Services.F1TV
+{
+    internal class SessionComparer : IEqualityComparer<Session>
+    {
+        public bool Equals(Session x, Session y)
+        {
+            return x?.ContentID == y?.ContentID;
+        }
+
+        public int GetHashCode([DisallowNull] Session session)
+        {
+            return session.ContentID.GetHashCode();
+        }
+    }
+}


### PR DESCRIPTION
* The first testing live session was reported by the API twice, added a comparer on ContentID (is that unique enough?) to `Distinct()` that. 
* Add start and end date (if any) to events
* Update README with info for developers.