### PR TITLE
Fix chromecast scanning

### DIFF
--- a/RaceControl/RaceControl/App.xaml.cs
+++ b/RaceControl/RaceControl/App.xaml.cs
@@ -14,6 +14,7 @@ using RaceControl.Common.Utils;
 using RaceControl.Core.Helpers;
 using RaceControl.Core.Settings;
 using RaceControl.Extensions;
+using RaceControl.GoogleCast;
 using RaceControl.Services.Credential;
 using RaceControl.Services.F1TV;
 using RaceControl.Services.Github;
@@ -30,7 +31,6 @@ using System.IO;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Threading;
-using RaceControl.GoogleCast;
 using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 using LibVLCSharpCore = LibVLCSharp.Shared.Core;
 using LogLevelNLog = NLog.LogLevel;
@@ -84,7 +84,7 @@ namespace RaceControl
                 .Register<IGithubService, GithubService>()
                 .Register<ICredentialService, CredentialService>()
                 .Register<INumberGenerator, NumberGenerator>()
-                .Register<CustomDeviceLocator>()
+                .Register<ICustomDeviceLocator, CustomDeviceLocator>()
                 .Register<ISender>(() => new Sender())
                 .Register<IMediaPlayer, VlcMediaPlayer>()
                 .Register<IMediaDownloader, VlcMediaDownloader>();

--- a/RaceControl/RaceControl/App.xaml.cs
+++ b/RaceControl/RaceControl/App.xaml.cs
@@ -30,6 +30,7 @@ using System.IO;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Threading;
+using RaceControl.GoogleCast;
 using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 using LibVLCSharpCore = LibVLCSharp.Shared.Core;
 using LogLevelNLog = NLog.LogLevel;
@@ -83,7 +84,7 @@ namespace RaceControl
                 .Register<IGithubService, GithubService>()
                 .Register<ICredentialService, CredentialService>()
                 .Register<INumberGenerator, NumberGenerator>()
-                .Register<IDeviceLocator, DeviceLocator>()
+                .Register<CustomDeviceLocator>()
                 .Register<ISender>(() => new Sender())
                 .Register<IMediaPlayer, VlcMediaPlayer>()
                 .Register<IMediaDownloader, VlcMediaDownloader>();

--- a/RaceControl/RaceControl/GoogleCast/CustomDeviceLocator.cs
+++ b/RaceControl/RaceControl/GoogleCast/CustomDeviceLocator.cs
@@ -1,24 +1,23 @@
-﻿using System;
+﻿using GoogleCast;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
-using System.Text;
 using System.Threading.Tasks;
-using GoogleCast;
 using Zeroconf;
 
 namespace RaceControl.GoogleCast
 {
-    public class CustomDeviceLocator : IDeviceLocator
+    public class CustomDeviceLocator : DeviceLocator, ICustomDeviceLocator
     {
-        private const string PROTOCOL = "_googlecast._tcp.local.";
+        private const string Protocol = "_googlecast._tcp.local.";
 
-        private Receiver CreateReceiver(IZeroconfHost host)
+        private static Receiver CreateReceiver(IZeroconfHost host)
         {
-            var service = host.Services[PROTOCOL];
+            var service = host.Services[Protocol];
             var properties = service.Properties.First();
-            return new Receiver()
+
+            return new Receiver
             {
                 Id = properties["id"],
                 FriendlyName = properties["fn"],
@@ -26,19 +25,9 @@ namespace RaceControl.GoogleCast
             };
         }
 
-        public Task<IEnumerable<IReceiver>> FindReceiversAsync()
-        {
-            throw new NotImplementedException();
-        }
-
-        public IObservable<IReceiver> FindReceiversContinuous()
-        {
-            throw new NotImplementedException();
-        }
-
         public async Task<IEnumerable<IReceiver>> FindReceiversAsync(NetworkInterface networkInterface)
         {
-            return (await ZeroconfResolver.ResolveAsync(PROTOCOL, netInterfacesToSendRequestOn: new NetworkInterface[] {networkInterface} )).Select(CreateReceiver);
+            return (await ZeroconfResolver.ResolveAsync(Protocol, netInterfacesToSendRequestOn: new[] { networkInterface })).Select(CreateReceiver);
         }
     }
 }

--- a/RaceControl/RaceControl/GoogleCast/CustomDeviceLocator.cs
+++ b/RaceControl/RaceControl/GoogleCast/CustomDeviceLocator.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Text;
+using System.Threading.Tasks;
+using GoogleCast;
+using Zeroconf;
+
+namespace RaceControl.GoogleCast
+{
+    public class CustomDeviceLocator : IDeviceLocator
+    {
+        private const string PROTOCOL = "_googlecast._tcp.local.";
+
+        private Receiver CreateReceiver(IZeroconfHost host)
+        {
+            var service = host.Services[PROTOCOL];
+            var properties = service.Properties.First();
+            return new Receiver()
+            {
+                Id = properties["id"],
+                FriendlyName = properties["fn"],
+                IPEndPoint = new IPEndPoint(IPAddress.Parse(host.IPAddress), service.Port)
+            };
+        }
+
+        public Task<IEnumerable<IReceiver>> FindReceiversAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<IReceiver> FindReceiversContinuous()
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<IEnumerable<IReceiver>> FindReceiversAsync(NetworkInterface networkInterface)
+        {
+            return (await ZeroconfResolver.ResolveAsync(PROTOCOL, netInterfacesToSendRequestOn: new NetworkInterface[] {networkInterface} )).Select(CreateReceiver);
+        }
+    }
+}

--- a/RaceControl/RaceControl/GoogleCast/ICustomDeviceLocator.cs
+++ b/RaceControl/RaceControl/GoogleCast/ICustomDeviceLocator.cs
@@ -1,0 +1,12 @@
+﻿using GoogleCast;
+using System.Collections.Generic;
+using System.Net.NetworkInformation;
+using System.Threading.Tasks;
+
+namespace RaceControl.GoogleCast
+{
+    public interface ICustomDeviceLocator : IDeviceLocator
+    {
+        Task<IEnumerable<IReceiver>> FindReceiversAsync(NetworkInterface networkInterface);
+    }
+}

--- a/RaceControl/RaceControl/RaceControl.csproj
+++ b/RaceControl/RaceControl/RaceControl.csproj
@@ -61,6 +61,7 @@
     <PackageReference Include="Prism.DryIoc" Version="8.0.0.1909" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="106.11.7" />
     <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.12" />
+    <PackageReference Include="Zeroconf" Version="3.4.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RaceControl.Core\RaceControl.Core.csproj" />

--- a/RaceControl/RaceControl/Views/MainWindow.xaml
+++ b/RaceControl/RaceControl/Views/MainWindow.xaml
@@ -482,16 +482,37 @@
                                 <Grid.RowDefinitions>
                                     <RowDefinition />
                                     <RowDefinition />
+                                    <RowDefinition />
                                 </Grid.RowDefinitions>
-                                <Button
+                                <TextBlock
                                     Grid.Row="0"
+                                    Grid.Column="0"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Text="Interface:" />
+                                <ComboBox 
+                                    Grid.Row="0" 
+                                    Grid.Column="1"
+                                    Margin="3"
+                                    DisplayMemberPath="Description"
+                                    IsEnabled="{Binding HasItems, RelativeSource={RelativeSource Self}}"
+                                    ItemsSource="{Binding NetworkInterfaces}"
+                                    SelectedItem="{Binding SelectedNetworkInterface}">
+                                    <i:Interaction.Triggers>
+                                        <i:EventTrigger EventName="SelectionChanged">
+                                            <i:InvokeCommandAction Command="{Binding ReceiverSelectionChangedCommand}" />
+                                        </i:EventTrigger>
+                                    </i:Interaction.Triggers>
+                                </ComboBox>
+                                <Button
+                                    Grid.Row="1"
                                     Grid.Column="0"
                                     Command="{Binding ScanReceiversCommand}"
                                     Content="Scan"
                                     Style="{StaticResource OptionButtonStyle}"
                                     ToolTip="Scan for Chromecast devices in local network" />
                                 <ComboBox
-                                    Grid.Row="0"
+                                    Grid.Row="1"
                                     Grid.Column="1"
                                     Margin="3"
                                     DisplayMemberPath="FriendlyName"
@@ -505,13 +526,13 @@
                                     </i:Interaction.Triggers>
                                 </ComboBox>
                                 <TextBlock
-                                    Grid.Row="1"
+                                    Grid.Row="2"
                                     Grid.Column="0"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
                                     Text="Audio:" />
                                 <ComboBox
-                                    Grid.Row="1"
+                                    Grid.Row="2"
                                     Grid.Column="1"
                                     Margin="3"
                                     DisplayMemberPath="Name"

--- a/RaceControl/RaceControl/Views/MainWindow.xaml
+++ b/RaceControl/RaceControl/Views/MainWindow.xaml
@@ -490,20 +490,14 @@
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
                                     Text="Interface:" />
-                                <ComboBox 
-                                    Grid.Row="0" 
+                                <ComboBox
+                                    Grid.Row="0"
                                     Grid.Column="1"
                                     Margin="3"
                                     DisplayMemberPath="Description"
                                     IsEnabled="{Binding HasItems, RelativeSource={RelativeSource Self}}"
                                     ItemsSource="{Binding NetworkInterfaces}"
-                                    SelectedItem="{Binding SelectedNetworkInterface}">
-                                    <i:Interaction.Triggers>
-                                        <i:EventTrigger EventName="SelectionChanged">
-                                            <i:InvokeCommandAction Command="{Binding ReceiverSelectionChangedCommand}" />
-                                        </i:EventTrigger>
-                                    </i:Interaction.Triggers>
-                                </ComboBox>
+                                    SelectedItem="{Binding SelectedNetworkInterface}" />
                                 <Button
                                     Grid.Row="1"
                                     Grid.Column="0"


### PR DESCRIPTION
potentially closes #79 

I had also an issue in finding my tv with built in chromecast.  The problem is the GoogleCast library doesn't scan in a specific interface.  When you specify an interface to the Zeroconf library it works.   I fixed this now by implementing a custom device locator that uses the selected network interface.   