### PR TITLE
Add settings to support an external MPV executable

### DIFF
--- a/RaceControl/RaceControl.Core/Settings/ISettings.cs
+++ b/RaceControl/RaceControl.Core/Settings/ISettings.cs
@@ -19,6 +19,8 @@ namespace RaceControl.Core.Settings
 
         string AdditionalMpvParameters { get; set; }
 
+        string CustomMpvPath { get; set; }
+
         string LatestRelease { get; set; }
 
         string SelectedNetworkInterface { get; set; }

--- a/RaceControl/RaceControl.Core/Settings/Settings.cs
+++ b/RaceControl/RaceControl.Core/Settings/Settings.cs
@@ -22,6 +22,7 @@ namespace RaceControl.Core.Settings
         private bool _disableMpvNoBorder;
         private bool _enableMpvAutoSync;
         private string _additionalMpvParameters;
+        private string _customMpvPath;
         private string _latestRelease;
         private string _selectedNetworkInterface;
         private ObservableCollection<string> _selectedSeries;
@@ -72,6 +73,12 @@ namespace RaceControl.Core.Settings
         {
             get => _additionalMpvParameters;
             set => SetProperty(ref _additionalMpvParameters, value);
+        }
+
+        public string CustomMpvPath
+        {
+            get => _customMpvPath;
+            set => SetProperty(ref _customMpvPath, value);
         }
 
         public string LatestRelease

--- a/RaceControl/RaceControl/ViewModels/MainWindowViewModel.cs
+++ b/RaceControl/RaceControl/ViewModels/MainWindowViewModel.cs
@@ -942,6 +942,18 @@ namespace RaceControl.ViewModels
                 }
             }
 
+            var useCustomMpvPath = false;
+            var customMpvPath = new String("");
+            if (!string.IsNullOrWhiteSpace(Settings.CustomMpvPath) && File.Exists(Settings.CustomMpvPath))
+            {
+                useCustomMpvPath = true;
+                customMpvPath = Settings.CustomMpvPath;
+            }
+            else if (!string.IsNullOrWhiteSpace(Settings.CustomMpvPath) && !File.Exists(Settings.CustomMpvPath))
+            {
+                Logger.Warn($"Error finding the MPV executable at '{Settings.CustomMpvPath}'. Falling back to the default MPV executable path. Please check your custom MPV path.");
+            }
+
             if (!hasAudioLanguage)
             {
                 var languageCodes = playableContent.GetAudioLanguages(Settings.DefaultAudioLanguage);
@@ -992,7 +1004,7 @@ namespace RaceControl.ViewModels
                 arguments.Add($"--mute={settings.IsMuted.GetYesNoString()}");
             }
 
-            using var process = ProcessUtils.CreateProcess(MpvExeLocation, string.Join(" ", arguments));
+            using var process = ProcessUtils.CreateProcess(useCustomMpvPath ? customMpvPath : MpvExeLocation, string.Join(" ", arguments));
             process.Start();
         }
 

--- a/RaceControl/RaceControl/ViewModels/MainWindowViewModel.cs
+++ b/RaceControl/RaceControl/ViewModels/MainWindowViewModel.cs
@@ -942,18 +942,6 @@ namespace RaceControl.ViewModels
                 }
             }
 
-            var useCustomMpvPath = false;
-            var customMpvPath = new String("");
-            if (!string.IsNullOrWhiteSpace(Settings.CustomMpvPath) && File.Exists(Settings.CustomMpvPath))
-            {
-                useCustomMpvPath = true;
-                customMpvPath = Settings.CustomMpvPath;
-            }
-            else if (!string.IsNullOrWhiteSpace(Settings.CustomMpvPath) && !File.Exists(Settings.CustomMpvPath))
-            {
-                Logger.Warn($"Error finding the MPV executable at '{Settings.CustomMpvPath}'. Falling back to the default MPV executable path. Please check your custom MPV path.");
-            }
-
             if (!hasAudioLanguage)
             {
                 var languageCodes = playableContent.GetAudioLanguages(Settings.DefaultAudioLanguage);
@@ -1004,7 +992,22 @@ namespace RaceControl.ViewModels
                 arguments.Add($"--mute={settings.IsMuted.GetYesNoString()}");
             }
 
-            using var process = ProcessUtils.CreateProcess(useCustomMpvPath ? customMpvPath : MpvExeLocation, string.Join(" ", arguments));
+            var mpvExeLocation = MpvExeLocation;
+            var customMpvPath = Settings.CustomMpvPath?.Trim();
+
+            if (!string.IsNullOrWhiteSpace(customMpvPath))
+            {
+                if (File.Exists(customMpvPath))
+                {
+                    mpvExeLocation = customMpvPath;
+                }
+                else
+                {
+                    Logger.Warn($"Could not find MPV executable at '{customMpvPath}', falling back to included MPV executable.");
+                }
+            }
+
+            using var process = ProcessUtils.CreateProcess(mpvExeLocation, string.Join(" ", arguments));
             process.Start();
         }
 

--- a/RaceControl/RaceControl/Views/MainWindow.xaml
+++ b/RaceControl/RaceControl/Views/MainWindow.xaml
@@ -440,8 +440,8 @@
                                         VerticalContentAlignment="Center"
                                         MaxLength="200"
                                         Text="{Binding Settings.AdditionalMpvParameters, UpdateSourceTrigger=PropertyChanged}" />
-									<TextBlock Margin="3" Text="Custom MPV path:" />
-									<TextBox
+                                    <TextBlock Margin="3" Text="Custom MPV path:" />
+                                    <TextBox
                                         Height="22"
                                         Margin="3,1"
                                         VerticalContentAlignment="Center"

--- a/RaceControl/RaceControl/Views/MainWindow.xaml
+++ b/RaceControl/RaceControl/Views/MainWindow.xaml
@@ -440,6 +440,13 @@
                                         VerticalContentAlignment="Center"
                                         MaxLength="200"
                                         Text="{Binding Settings.AdditionalMpvParameters, UpdateSourceTrigger=PropertyChanged}" />
+									<TextBlock Margin="3" Text="Custom MPV path:" />
+									<TextBox
+                                        Height="22"
+                                        Margin="3,1"
+                                        VerticalContentAlignment="Center"
+                                        MaxLength="200"
+                                        Text="{Binding Settings.CustomMpvPath, UpdateSourceTrigger=PropertyChanged}" />
                                 </StackPanel>
                             </GroupBox>
                             <GroupBox


### PR DESCRIPTION
Added an extra textbox that allows a user to specify the path of an external MPV media player executable. 

I had a weird edge case where the included MPV player that is installed with Race Control would not open the stream (or any file in my testing). It might have been due to the fact that I already had an older version of MPV installed and setup. I originally created a sym link that linked the Race Control MPV dir with the pre-installed MPV dir as a work around, but that wasn't an ideal solution. Adding an option to specify an external MPV executable and override the default path seemed like it would work well.