### PR TITLE
Add setting to skip save dialog

### DIFF
--- a/RaceControl/RaceControl.Core/Settings/ISettings.cs
+++ b/RaceControl/RaceControl.Core/Settings/ISettings.cs
@@ -18,6 +18,8 @@ namespace RaceControl.Core.Settings
 
         string RecordingLocation { get; set; }
 
+        bool SkipSaveDialog { get; set; }
+
         bool DisableThumbnailTooltips { get; set; }
 
         bool DisableLiveSessionNotification { get; set; }

--- a/RaceControl/RaceControl.Core/Settings/Settings.cs
+++ b/RaceControl/RaceControl.Core/Settings/Settings.cs
@@ -22,6 +22,7 @@ namespace RaceControl.Core.Settings
         private string _defaultAudioLanguage;
         private VideoQuality _defaultVideoQuality;
         private string _recordingLocation = FolderUtils.GetSpecialFolderPath(Environment.SpecialFolder.Desktop);
+        private bool _skipSaveDialog;
         private bool _disableThumbnailTooltips;
         private bool _disableLiveSessionNotification;
         private bool _disableMpvNoBorder;
@@ -72,6 +73,12 @@ namespace RaceControl.Core.Settings
         {
             get => _recordingLocation;
             set => SetProperty(ref _recordingLocation, value);
+        }
+
+        public bool SkipSaveDialog
+        {
+            get => _skipSaveDialog;
+            set => SetProperty(ref _skipSaveDialog, value);
         }
 
         public bool DisableThumbnailTooltips

--- a/RaceControl/RaceControl/ViewModels/MainWindowViewModel.cs
+++ b/RaceControl/RaceControl/ViewModels/MainWindowViewModel.cs
@@ -1113,8 +1113,9 @@ namespace RaceControl.ViewModels
         {
             var defaultFilename = $"{playableContent.Title}.mp4".RemoveInvalidFileNameChars();
             var initialDirectory = !string.IsNullOrWhiteSpace(Settings.RecordingLocation) ? Settings.RecordingLocation : FolderUtils.GetSpecialFolderPath(Environment.SpecialFolder.Desktop);
+            var filename = Path.Join(initialDirectory, defaultFilename);
 
-            if (_dialogService.SaveFile("Select a filename", initialDirectory, defaultFilename, ".mp4", out var filename))
+            if (Settings.SkipSaveDialog || _dialogService.SaveFile("Select a filename", initialDirectory, defaultFilename, ".mp4", out filename))
             {
                 var parameters = new DialogParameters
                 {

--- a/RaceControl/RaceControl/Views/MainWindow.xaml
+++ b/RaceControl/RaceControl/Views/MainWindow.xaml
@@ -443,6 +443,10 @@
                                         Text="{Binding Settings.RecordingLocation, UpdateSourceTrigger=PropertyChanged}" />
                                     <CheckBox
                                         Margin="3"
+                                        Content="Skip save dialog"
+                                        IsChecked="{Binding Settings.SkipSaveDialog}" />
+                                    <CheckBox
+                                        Margin="3"
                                         Content="Disable thumbnail tooltips"
                                         IsChecked="{Binding Settings.DisableThumbnailTooltips}" />
                                     <CheckBox


### PR DESCRIPTION
Added a setting "Skip save dialog" that when checked skips asking for a location/filename when attempting to download a file and uses the default "Recording location" and default filename instead.

Not sure if "Skip save dialog" is a great label for the checkbox, feel free to propose a better label.