### PR TITLE
[FEATURE] Re-Enable Resizable Window when exiting fullscreen #240

### DIFF
--- a/RaceControl/RaceControl/ViewModels/VideoDialogViewModel.cs
+++ b/RaceControl/RaceControl/ViewModels/VideoDialogViewModel.cs
@@ -641,11 +641,7 @@ public class VideoDialogViewModel : DialogViewModelBase
 
     private void SetWindowed(ResizeMode? resizeMode = null)
     {
-        if (resizeMode.HasValue)
-        {
-            DialogSettings.ResizeMode = resizeMode.Value;
-        }
-
+        DialogSettings.ResizeMode = resizeMode ?? ResizeMode.CanResize;
         DialogSettings.FullScreen = false;
     }
 


### PR DESCRIPTION
Implement #240 

Issue in short:
When you start a stream the resizable window is enabled. But if you leave fullscreen it would still be disabled.

Changes:
Changed the if statement to assign the ResizeMode.CanResize if the provided param is null. (Which also fixes assigning a null to a non-nullable property)

Tested with single and multiple running streams. 
Only the described issue/feature is affected. Moving to corner will still set ResizeMode to NoResize