### PR TITLE
Re-Enable Resizable Window when exiting fullscreen using mediakeys

### DIFF
--- a/RaceControl/RaceControl/ViewModels/VideoDialogViewModel.cs
+++ b/RaceControl/RaceControl/ViewModels/VideoDialogViewModel.cs
@@ -450,6 +450,11 @@ public class VideoDialogViewModel : DialogViewModelBase
             SetWindowed();
             SetFullScreen();
         }
+        // Needed to set the resizemode to 'NoResize' when exiting fullscreen using a Windows key combination
+        else if (window.WindowState == WindowState.Normal)
+        {
+            SetWindowed();
+        }
     }
 
     private void OnSyncStreams(SyncStreamsEventPayload payload)

--- a/RaceControl/RaceControl/ViewModels/VideoDialogViewModel.cs
+++ b/RaceControl/RaceControl/ViewModels/VideoDialogViewModel.cs
@@ -450,7 +450,7 @@ public class VideoDialogViewModel : DialogViewModelBase
             SetWindowed();
             SetFullScreen();
         }
-        // Needed to set the resizemode to 'NoResize' when exiting fullscreen using a Windows key combination
+        // Needed to set the resizemode to 'CanResize' when exiting fullscreen using a Windows key combination
         else if (window.WindowState == WindowState.Normal)
         {
             SetWindowed();


### PR DESCRIPTION
In addition to PR #361 

When exiting fullscreen using the WinKey combination the window would not become resizable again, same as in #240 .
Added calling the SetWindowed() logic in the same way as going into fullscreen with windows keys is handled