### PR TITLE
Required subscription

### DIFF
--- a/RaceControl/RaceControl.Common/Interfaces/IPlayableContent.cs
+++ b/RaceControl/RaceControl.Common/Interfaces/IPlayableContent.cs
@@ -13,4 +13,5 @@ public interface IPlayableContent
     bool IsLive { get; }
     string SyncUID { get; }
     string SeriesUID { get; }
+    string RequiredSubscriptionLevel { get; }
 }

--- a/RaceControl/RaceControl/PlayableChannel.cs
+++ b/RaceControl/RaceControl/PlayableChannel.cs
@@ -14,6 +14,7 @@ public class PlayableChannel : PlayableContent
         IsLive = session.IsLive;
         SyncUID = session.UID;
         SeriesUID = session.SeriesUID;
+        RequiredSubscriptionLevel = channel.RequiredSubcriptionLevel ?? "Pro";
     }
 
     private static string GetDisplayName(Season season, Channel channel)

--- a/RaceControl/RaceControl/PlayableContent.cs
+++ b/RaceControl/RaceControl/PlayableContent.cs
@@ -11,6 +11,7 @@ public abstract class PlayableContent : IPlayableContent
     public bool IsLive { get; protected init; }
     public string SyncUID { get; protected init; }
     public string SeriesUID { get; protected init; }
+    public string RequiredSubscriptionLevel { get; protected init; }
 
     public override string ToString()
     {

--- a/RaceControl/RaceControl/PlayableEpisode.cs
+++ b/RaceControl/RaceControl/PlayableEpisode.cs
@@ -12,5 +12,6 @@ public class PlayableEpisode : PlayableContent
         ThumbnailUrl = episode.ThumbnailUrl;
         SyncUID = episode.UID;
         SeriesUID = episode.SeriesUID;
+        RequiredSubscriptionLevel = episode.RequiredSubscriptionLevel ?? "Pro";
     }
 }

--- a/RaceControl/RaceControl/ViewModels/MainWindowViewModel.cs
+++ b/RaceControl/RaceControl/ViewModels/MainWindowViewModel.cs
@@ -877,6 +877,7 @@ public class MainWindowViewModel : ViewModelBase, ICloseWindow
 
     private void WatchContent(IPlayableContent playableContent, VideoDialogSettings settings = null)
     {
+        ValidateActiveSubscription(playableContent);
         var identifier = _numberGenerator.GetNextNumber();
         var parameters = new DialogParameters
             {
@@ -886,10 +887,11 @@ public class MainWindowViewModel : ViewModelBase, ICloseWindow
             };
 
         _dialogService.Show(nameof(VideoDialog), parameters, _ => _numberGenerator.RemoveNumber(identifier), nameof(VideoDialogWindow));
-    }
+    }    
 
     private async Task WatchInVlcAsync(IPlayableContent playableContent)
     {
+        ValidateActiveSubscription(playableContent);
         var streamUrl = await _apiService.GetTokenisedUrlAsync(Settings.SubscriptionToken, playableContent);
         ValidateStreamUrl(streamUrl);
         using var process = ProcessUtils.CreateProcess(VlcExeLocation, $"\"{streamUrl}\" --meta-title=\"{playableContent.Title}\"");
@@ -898,6 +900,7 @@ public class MainWindowViewModel : ViewModelBase, ICloseWindow
 
     private async Task WatchInMpvAsync(IPlayableContent playableContent, VideoDialogSettings settings = null)
     {
+        ValidateActiveSubscription(playableContent);
         // Use different stream type because this one doesn't require a playToken cookie (not supported by MPV)
         var streamUrl = await _apiService.GetTokenisedUrlAsync(Settings.SubscriptionToken, playableContent, StreamTypeKeys.BigScreenHls);
         ValidateStreamUrl(streamUrl);
@@ -1003,6 +1006,7 @@ public class MainWindowViewModel : ViewModelBase, ICloseWindow
 
     private async Task WatchInMpcAsync(IPlayableContent playableContent)
     {
+        ValidateActiveSubscription(playableContent);
         var streamUrl = await _apiService.GetTokenisedUrlAsync(Settings.SubscriptionToken, playableContent);
         ValidateStreamUrl(streamUrl);
         using var process = ProcessUtils.CreateProcess(MpcExeLocation, $"\"{streamUrl}\"");
@@ -1011,6 +1015,7 @@ public class MainWindowViewModel : ViewModelBase, ICloseWindow
 
     private async Task CastContentAsync(IReceiver receiver, IPlayableContent playableContent)
     {
+        ValidateActiveSubscription(playableContent);
         var streamUrl = await _apiService.GetTokenisedUrlAsync(Settings.SubscriptionToken, playableContent);
         ValidateStreamUrl(streamUrl);
         AudioTracks.Clear();
@@ -1069,6 +1074,7 @@ public class MainWindowViewModel : ViewModelBase, ICloseWindow
 
     private async Task CopyUrlAsync(IPlayableContent playableContent)
     {
+        ValidateActiveSubscription(playableContent);
         var streamUrl = await _apiService.GetTokenisedUrlAsync(Settings.SubscriptionToken, playableContent);
         ValidateStreamUrl(streamUrl);
         Clipboard.SetText(streamUrl);
@@ -1076,6 +1082,7 @@ public class MainWindowViewModel : ViewModelBase, ICloseWindow
 
     private void StartDownload(IPlayableContent playableContent)
     {
+        ValidateActiveSubscription(playableContent);
         var defaultFilename = $"{playableContent.Title}.mp4".RemoveInvalidFileNameChars();
         var initialDirectory = !string.IsNullOrWhiteSpace(Settings.RecordingLocation) ? Settings.RecordingLocation : FolderUtils.GetSpecialFolderPath(Environment.SpecialFolder.Desktop);
         var filename = Path.Join(initialDirectory, defaultFilename);
@@ -1202,11 +1209,19 @@ public class MainWindowViewModel : ViewModelBase, ICloseWindow
         SelectedVodGenre = null;
     }
 
+    private void ValidateActiveSubscription(IPlayableContent playableContent)
+    {
+        if (Settings.SubscriptionStatus.ToLower() != "active")
+        {
+            throw new InvalidOperationException($"Failed to execute action: \nAn active F1TV subscription is required of type '{playableContent.RequiredSubscriptionLevel}' or higher");
+        }
+    }
+
     private static void ValidateStreamUrl(string streamUrl)
     {
         if (string.IsNullOrWhiteSpace(streamUrl))
         {
-            throw new Exception("An error occurred while retrieving the stream URL.");
+            throw new ArgumentException("An error occurred while retrieving the stream URL.");
         }
     }
 

--- a/RaceControl/Services/RaceControl.Services.Interfaces/F1TV/Entities/Channel.cs
+++ b/RaceControl/Services/RaceControl.Services.Interfaces/F1TV/Entities/Channel.cs
@@ -5,4 +5,5 @@ public class Channel
     public string Name { get; init; }
     public string ChannelType { get; init; }
     public string PlaybackUrl { get; init; }
+    public string RequiredSubcriptionLevel { get; init; }
 }

--- a/RaceControl/Services/RaceControl.Services.Interfaces/F1TV/Entities/Episode.cs
+++ b/RaceControl/Services/RaceControl.Services.Interfaces/F1TV/Entities/Episode.cs
@@ -16,6 +16,7 @@ public class Episode
     public DateTime? ContractStartDate { get; init; }
     public DateTime? ContractEndDate { get; init; }
     public long SessionIndex { get; init; }
+    public string RequiredSubscriptionLevel { get; init; }
 
     public override string ToString()
     {

--- a/RaceControl/Services/RaceControl.Services/F1TV/ApiService.cs
+++ b/RaceControl/Services/RaceControl.Services/F1TV/ApiService.cs
@@ -151,7 +151,8 @@ public class ApiService : IApiService
                     // Add the world feed seperately
                     Name = ChannelNames.Wif,
                     ChannelType = ChannelTypes.Wif,
-                    PlaybackUrl = GetPlaybackUrl(metadata.ContentId)
+                    PlaybackUrl = GetPlaybackUrl(metadata.ContentId),
+                    RequiredSubcriptionLevel = metadata.Entitlement
                 }
             };
 

--- a/RaceControl/Services/RaceControl.Services/F1TV/ApiService.cs
+++ b/RaceControl/Services/RaceControl.Services/F1TV/ApiService.cs
@@ -163,7 +163,8 @@ public class ApiService : IApiService
                 {
                     Name = s.Type == ChannelTypes.Onboard ? $"{s.DriverFirstName} {s.DriverLastName}" : s.Title,
                     ChannelType = s.Type,
-                    PlaybackUrl = s.PlaybackUrl
+                    PlaybackUrl = s.PlaybackUrl,
+                    RequiredSubcriptionLevel = metadata.Entitlement
                 })
                 .ToList());
         }
@@ -365,7 +366,8 @@ public class ApiService : IApiService
             EndDate = container.Metadata.EmfAttributes.SessionEndDate.GetDateTimeFromEpoch(),
             ContractStartDate = container.Metadata.ContractStartDate.GetDateTimeFromEpoch(),
             ContractEndDate = container.Metadata.ContractEndDate.GetDateTimeFromEpoch(),
-            SessionIndex = container.Metadata.EmfAttributes.SessionIndex
+            SessionIndex = container.Metadata.EmfAttributes.SessionIndex,
+            RequiredSubscriptionLevel = container.Metadata.Entitlement
         };
     }
 


### PR DESCRIPTION
There are several new issues about failing to start a stream where some of them the issue was not having an active F1TV subscription. #333 and  #363
In order to add to the user-experience I have made a simple validation and errormessage for this case.

Functionality changes:
When users try to watch content without a valid F1TV subscription an user-friendly error will be shown along with the minimum subscription level needed for that content (Access/Pro).
![image](https://user-images.githubusercontent.com/5929773/159185132-cc144e91-101b-4a33-8774-f9245fd55cef.png)


Code Changes:
- Added the minimum subscriptionlevel needed for F1TV resources to the IPlayableContent and its implementations. This field comes from the F1TV api response field 'Entitlement'.
- Added a simple validation on SubscriptionStatus at the start of the watch and download-actions. 

Sadly we do not know the type of subscription the user has since F1TV does not return that upon authorizing.(Maybe there is a different way, but didnt check as I went for a simple validation)